### PR TITLE
Allow errors to be returned from the replace with closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonpath_lib"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Changseok Han <freestrings@gmail.com>"]
 
 description = "It is JsonPath engine written in Rust. it provide a similar API interface in Webassembly and Javascript too. - Webassembly Demo: https://freestrings.github.io/jsonpath"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ pub fn delete(value: Value, path: &str) -> Result<Value, JsonPathError> {
 ///         0
 ///     };
 ///
-///     Ok(json!(age))
+///     Ok(Some(json!(age)))
 /// }).unwrap();
 ///
 /// assert_eq!(ret, json!({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ pub fn delete(value: Value, path: &str) -> Result<Value, JsonPathError> {
 ///         0
 ///     };
 ///
-///     Some(json!(age))
+///     Ok(json!(age))
 /// }).unwrap();
 ///
 /// assert_eq!(ret, json!({
@@ -467,7 +467,7 @@ pub fn delete(value: Value, path: &str) -> Result<Value, JsonPathError> {
 /// ```
 pub fn replace_with<F>(value: Value, path: &str, fun: &mut F) -> Result<Value, JsonPathError>
 where
-    F: FnMut(Value) -> Option<Value>,
+    F: FnMut(Value) -> Result<Option<Value>, JsonPathError>,
 {
     let mut selector = SelectorMut::default();
     let value = selector.str_path(path)?.value(value).replace_with(fun)?;

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -224,7 +224,7 @@ fn readme_selector_mut() {
                 0
             };
 
-            Some(json!(age))
+            Ok(Some(json!(age)))
         })
         .unwrap()
         .take()
@@ -522,7 +522,7 @@ fn readme_replace_with() {
             0
         };
 
-        Some(json!(age))
+        Ok(Some(json!(age)))
     })
     .unwrap();
 

--- a/tests/selector.rs
+++ b/tests/selector.rs
@@ -3,7 +3,7 @@ extern crate jsonpath_lib as jsonpath;
 extern crate serde_json;
 
 use common::{read_json, setup};
-use jsonpath::{Parser, Selector, SelectorMut};
+use jsonpath::{Parser, Selector, SelectorMut, JsonPathError};
 use serde_json::Value;
 
 mod common;
@@ -23,7 +23,7 @@ fn selector_mut() {
             if let Value::Number(n) = v {
                 nums.push(n.as_f64().unwrap());
             }
-            Some(Value::String("a".to_string()))
+            Ok(Some(Value::String("a".to_string())))
         })
         .unwrap()
         .take()
@@ -51,6 +51,25 @@ fn selector_mut() {
             &json!("a")
         ],
         result
+    );
+}
+
+#[test]
+fn selector_mut_err() {
+    setup();
+
+    let mut selector_mut = SelectorMut::default();
+    let result = selector_mut
+        .str_path(r#"$.store..price"#)
+        .unwrap()
+        .value(read_json("./benchmark/example.json"))
+        .replace_with(&mut |_| {
+            Err(JsonPathError::EmptyValue)
+        });
+
+    assert_eq!(
+        result.is_err(),
+        true
     );
 }
 


### PR DESCRIPTION
# Why

Replace with only returns options, which only allows for a new value to be put into the json object, or the value to be deleted. It does not allow the replace with closure to fail

# How

Wrap the option in a result to allow the closure to short circuit on error